### PR TITLE
[Feat] Style, Font Extension #6

### DIFF
--- a/EZPZ/EZPZ.xcodeproj/project.pbxproj
+++ b/EZPZ/EZPZ.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7003404E28FC93C20066C59B /* Spoqa Han Sans Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7003404C28FC93C10066C59B /* Spoqa Han Sans Regular.ttf */; };
+		7003404F28FC93C20066C59B /* Spoqa Han Sans Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7003404D28FC93C20066C59B /* Spoqa Han Sans Bold.ttf */; };
 		70761C0228FB1327000D399A /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 70761C0128FB1327000D399A /* Colors.xcassets */; };
 		70761C0428FB18FB000D399A /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70761C0328FB18FB000D399A /* Color+.swift */; };
 		70761C0628FB2034000D399A /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70761C0528FB2034000D399A /* View+.swift */; };
@@ -26,6 +28,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		7003404C28FC93C10066C59B /* Spoqa Han Sans Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Spoqa Han Sans Regular.ttf"; sourceTree = "<group>"; };
+		7003404D28FC93C20066C59B /* Spoqa Han Sans Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Spoqa Han Sans Bold.ttf"; sourceTree = "<group>"; };
 		70761C0128FB1327000D399A /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		70761C0328FB18FB000D399A /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		70761C0528FB2034000D399A /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
@@ -57,6 +61,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7003404B28FC93A70066C59B /* Fonts */ = {
+			isa = PBXGroup;
+			children = (
+				7003404D28FC93C20066C59B /* Spoqa Han Sans Bold.ttf */,
+				7003404C28FC93C10066C59B /* Spoqa Han Sans Regular.ttf */,
+			);
+			path = Fonts;
+			sourceTree = "<group>";
+		};
 		D50154C028FAD6AB001BA8D5 /* OnBoardingView */ = {
 			isa = PBXGroup;
 			children = (
@@ -135,6 +148,7 @@
 		D593994428EE10130082A3F9 /* EZPZ */ = {
 			isa = PBXGroup;
 			children = (
+				7003404B28FC93A70066C59B /* Fonts */,
 				D593995D28EE11630082A3F9 /* Resources */,
 				D593995C28EE11350082A3F9 /* Models */,
 				D593995A28EE11260082A3F9 /* Views */,
@@ -251,7 +265,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7003404E28FC93C20066C59B /* Spoqa Han Sans Regular.ttf in Resources */,
 				D593994D28EE10140082A3F9 /* Preview Assets.xcassets in Resources */,
+				7003404F28FC93C20066C59B /* Spoqa Han Sans Bold.ttf in Resources */,
 				D593994A28EE10140082A3F9 /* Assets.xcassets in Resources */,
 				70761C0228FB1327000D399A /* Colors.xcassets in Resources */,
 			);
@@ -408,6 +424,7 @@
 				DEVELOPMENT_TEAM = 5N5TS7Y4MA;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = EZPZ/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -437,6 +454,7 @@
 				DEVELOPMENT_TEAM = 5N5TS7Y4MA;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = EZPZ/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/EZPZ/EZPZ.xcodeproj/project.pbxproj
+++ b/EZPZ/EZPZ.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		70761C0228FB1327000D399A /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 70761C0128FB1327000D399A /* Colors.xcassets */; };
+		70761C0428FB18FB000D399A /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70761C0328FB18FB000D399A /* Color+.swift */; };
+		70761C0628FB2034000D399A /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70761C0528FB2034000D399A /* View+.swift */; };
+		70761C0828FB2805000D399A /* Text+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70761C0728FB2805000D399A /* Text+.swift */; };
 		D50154C728FAD73D001BA8D5 /* MainChallengeSuperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50154C628FAD73D001BA8D5 /* MainChallengeSuperView.swift */; };
 		D50154C928FAD74A001BA8D5 /* MainChallengeEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50154C828FAD74A001BA8D5 /* MainChallengeEmptyView.swift */; };
 		D50154CC28FAD77B001BA8D5 /* TodoEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50154CB28FAD77B001BA8D5 /* TodoEditView.swift */; };
@@ -22,6 +26,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		70761C0128FB1327000D399A /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		70761C0328FB18FB000D399A /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
+		70761C0528FB2034000D399A /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
+		70761C0728FB2805000D399A /* Text+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+.swift"; sourceTree = "<group>"; };
 		D50154C628FAD73D001BA8D5 /* MainChallengeSuperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainChallengeSuperView.swift; sourceTree = "<group>"; };
 		D50154C828FAD74A001BA8D5 /* MainChallengeEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainChallengeEmptyView.swift; sourceTree = "<group>"; };
 		D50154CB28FAD77B001BA8D5 /* TodoEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoEditView.swift; sourceTree = "<group>"; };
@@ -101,6 +109,9 @@
 			isa = PBXGroup;
 			children = (
 				D50154D328FAD825001BA8D5 /* imsi+.swift */,
+				70761C0328FB18FB000D399A /* Color+.swift */,
+				70761C0528FB2034000D399A /* View+.swift */,
+				70761C0728FB2805000D399A /* Text+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -129,6 +140,7 @@
 				D593995A28EE11260082A3F9 /* Views */,
 				D593995B28EE112D0082A3F9 /* ViewModels */,
 				D593994528EE10130082A3F9 /* EZPZApp.swift */,
+				70761C0128FB1327000D399A /* Colors.xcassets */,
 				D50154D228FAD817001BA8D5 /* Extensions */,
 				D593995328EE10140082A3F9 /* Info.plist */,
 				D593994B28EE10140082A3F9 /* Preview Content */,
@@ -241,6 +253,7 @@
 			files = (
 				D593994D28EE10140082A3F9 /* Preview Assets.xcassets in Resources */,
 				D593994A28EE10140082A3F9 /* Assets.xcassets in Resources */,
+				70761C0228FB1327000D399A /* Colors.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -251,14 +264,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70761C0828FB2805000D399A /* Text+.swift in Sources */,
 				D593995F28EE11F60082A3F9 /* imsi.swift in Sources */,
 				D593994F28EE10140082A3F9 /* Persistence.swift in Sources */,
 				D593994828EE10130082A3F9 /* ContentView.swift in Sources */,
 				D50154C728FAD73D001BA8D5 /* MainChallengeSuperView.swift in Sources */,
+				70761C0628FB2034000D399A /* View+.swift in Sources */,
 				D50154CC28FAD77B001BA8D5 /* TodoEditView.swift in Sources */,
 				D50154D428FAD825001BA8D5 /* imsi+.swift in Sources */,
 				D593995228EE10140082A3F9 /* EZPZ.xcdatamodeld in Sources */,
 				D50154C928FAD74A001BA8D5 /* MainChallengeEmptyView.swift in Sources */,
+				70761C0428FB18FB000D399A /* Color+.swift in Sources */,
 				D50154CE28FAD78C001BA8D5 /* MainChallengePinView.swift in Sources */,
 				D593994628EE10130082A3F9 /* EZPZApp.swift in Sources */,
 			);

--- a/EZPZ/EZPZ/Colors.xcassets/CardGreen.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/CardGreen.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.486",
+          "green" : "0.847",
+          "red" : "0.604"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7C",
+          "green" : "0xD8",
+          "red" : "0x9A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/CardOatmeal.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/CardOatmeal.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.714",
+          "green" : "0.863",
+          "red" : "0.875"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB6",
+          "green" : "0xDC",
+          "red" : "0xDF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/CardPink.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/CardPink.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.553",
+          "green" : "0.588",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x8D",
+          "green" : "0x96",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/CardPurple.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/CardPurple.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.843",
+          "green" : "0.776",
+          "red" : "0.910"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD7",
+          "green" : "0xC6",
+          "red" : "0xE8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/CardSkyblue.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/CardSkyblue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.808",
+          "green" : "0.886",
+          "red" : "0.322"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCE",
+          "green" : "0xE2",
+          "red" : "0x52"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/Cardblue.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/Cardblue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.757",
+          "red" : "0.337"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xC1",
+          "red" : "0x56"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/EZPZBlack.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/EZPZBlack.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.071",
+          "green" : "0.071",
+          "red" : "0.071"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/EZPZLime.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/EZPZLime.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5C",
+          "green" : "0xFF",
+          "red" : "0xE6"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5C",
+          "green" : "0xFF",
+          "red" : "0xE6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/EZPZPink.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/EZPZPink.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x74",
+          "green" : "0x51",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x74",
+          "green" : "0x51",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/Grayscale1.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/Grayscale1.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xF2",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xF2",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/Grayscale2.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/Grayscale2.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x8D",
+          "green" : "0x8A",
+          "red" : "0x8A"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x8D",
+          "green" : "0x8A",
+          "red" : "0x8A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/Grayscale3.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/Grayscale3.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.365",
+          "green" : "0.365",
+          "red" : "0.365"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5D",
+          "green" : "0x5D",
+          "red" : "0x5D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/Grayscale4.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/Grayscale4.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.196",
+          "red" : "0.196"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x32",
+          "red" : "0x32"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Colors.xcassets/Grayscale5.colorset/Contents.json
+++ b/EZPZ/EZPZ/Colors.xcassets/Grayscale5.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.208",
+          "green" : "0.208",
+          "red" : "0.208"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x35",
+          "green" : "0x35",
+          "red" : "0x35"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EZPZ/EZPZ/Extensions/Color+.swift
+++ b/EZPZ/EZPZ/Extensions/Color+.swift
@@ -1,0 +1,31 @@
+//
+//  Color+.swift
+//  EZPZ
+//
+//  Created by Ruyha on 2022/10/16.
+//
+
+import SwiftUI
+
+extension Color{
+    
+    // MAIN COLOR
+    static let ezpzPink = Color("EZPZPink")
+    static let ezpzLime = Color("EZPZLime")
+    
+    // GRAY COLOR
+    static let grayScale1 = Color("Grayscale1")
+    static let grayScale2 = Color("Grayscale2")
+    static let grayScale3 = Color("Grayscale3")
+    static let grayScale4 = Color("Grayscale4")
+    static let grayScale5 = Color("Grayscale5")
+    static let ezpzBlack = Color("EZPZBlack")
+    
+    // ECT
+    static let cardPink = Color("CardPink")
+    static let cardPurple = Color("CardPurple")
+    static let cardOatmeal = Color("CardOatmeal")
+    static let cardGreen = Color("CardGreen")
+    static let cardSkyblue = Color("CardSkyblue")
+    static let cardblue = Color("Cardblue")
+}

--- a/EZPZ/EZPZ/Extensions/Text+.swift
+++ b/EZPZ/EZPZ/Extensions/Text+.swift
@@ -14,6 +14,10 @@ extension Font {
     static let price = Font.custom("GillSans-SemiBoldItalic", size: 12)
 }
 
+/*
+ === SpoqaHanSans-Regular
+ === SpoqaHanSans-Bold
+ */
 extension Text {
     func basicTitle1() -> Text {
         self.font(Font.custom("ppap", size: 34))

--- a/EZPZ/EZPZ/Extensions/Text+.swift
+++ b/EZPZ/EZPZ/Extensions/Text+.swift
@@ -7,85 +7,74 @@
 
 import SwiftUI
 
-extension Font {
-    static let name = Font.custom("GillSans-UltraBold", size: 14)
-    static let location = Font.custom("GillSans-SemiBold", size: 10)
-    static let date = Font.custom("GillSans-UltraBold", size: 16)
-    static let price = Font.custom("GillSans-SemiBoldItalic", size: 12)
-}
-
-/*
- === SpoqaHanSans-Regular
- === SpoqaHanSans-Bold
- */
 extension Text {
     func basicTitle1() -> Text {
-        self.font(Font.custom("ppap", size: 34))
+        self.font(Font.custom("SpoqaHanSans-Bold", size: 34))
             .foregroundColor(.grayScale1)
     }
     
     func limeTitle1() -> Text {
-        self.font(Font.custom("ppap", size: 34))
+        self.font(Font.custom("SpoqaHanSans-Bold", size: 34))
             .foregroundColor(.ezpzLime)
     }
     
     func basicTitle2() -> Text {
-        self.font(Font.custom("ppap", size: 28))
+        self.font(Font.custom("SpoqaHanSans-Bold", size: 28))
             .foregroundColor(.grayScale1)
     }
     
     func limeTitle2() -> Text {
-        self.font(Font.custom("ppap", size: 28))
+        self.font(Font.custom("SpoqaHanSans-Bold", size: 28))
             .foregroundColor(.ezpzLime)
     }
     
     func pinkTitle3() -> Text {
-        self.font(Font.custom("ppap", size: 24))
+        self.font(Font.custom("SpoqaHanSans-Bold", size: 24))
             .foregroundColor(.ezpzPink)
     }
     
     func limeTitle4() -> Text {
-        self.font(Font.custom("ppap", size: 18))
+        self.font(Font.custom("SpoqaHanSans-Bold", size: 18))
             .foregroundColor(.ezpzLime)
     }
     
     func basicHeadline() -> Text {
-        self.font(Font.custom("ppap", size: 17))
+        self.font(Font.custom("SpoqaHanSans-Bold", size: 17))
             .foregroundColor(.grayScale1)
     }
     
     func limeHeadline() -> Text {
-        self.font(Font.custom("ppap", size: 17))
+        self.font(Font.custom("SpoqaHanSans-Bold", size: 17))
             .foregroundColor(.ezpzLime)
     }
     
     func basicBody() -> Text {
-        self.font(Font.custom("ppap", size: 17))
+        self.font(Font.custom("SpoqaHanSans-Regular", size: 17))
             .foregroundColor(.grayScale1)
     }
     
     func grayScale3Body() -> Text {
-        self.font(Font.custom("ppap", size: 17))
+        self.font(Font.custom("SpoqaHanSans-Regular", size: 17))
             .foregroundColor(.grayScale3)
     }
     
     func grayScale4Body() -> Text {
-        self.font(Font.custom("ppap", size: 17))
+        self.font(Font.custom("SpoqaHanSans-Regular", size: 17))
             .foregroundColor(.grayScale4)
     }
     
     func grayScale3Caption() -> Text {
-        self.font(Font.custom("ppap", size: 13))
+        self.font(Font.custom("SpoqaHanSans-Regular", size: 13))
             .foregroundColor(.grayScale3)
     }
     
     func limeCaption() -> Text {
-        self.font(Font.custom("ppap", size: 13))
+        self.font(Font.custom("SpoqaHanSans-Regular", size: 13))
             .foregroundColor(.ezpzLime)
     }
     
     func grayScale3Headline() -> Text {
-        self.font(Font.custom("ppap", size: 17))
+        self.font(Font.custom("SpoqaHanSans-Bold", size: 17))
             .foregroundColor(.grayScale3)
     }
 }

--- a/EZPZ/EZPZ/Extensions/Text+.swift
+++ b/EZPZ/EZPZ/Extensions/Text+.swift
@@ -1,0 +1,87 @@
+//
+//  Text+.swift
+//  EZPZ
+//
+//  Created by Ruyha on 2022/10/16.
+//
+
+import SwiftUI
+
+extension Font {
+    static let name = Font.custom("GillSans-UltraBold", size: 14)
+    static let location = Font.custom("GillSans-SemiBold", size: 10)
+    static let date = Font.custom("GillSans-UltraBold", size: 16)
+    static let price = Font.custom("GillSans-SemiBoldItalic", size: 12)
+}
+
+extension Text {
+    func basicTitle1() -> Text {
+        self.font(Font.custom("ppap", size: 34))
+            .foregroundColor(.grayScale1)
+    }
+    
+    func limeTitle1() -> Text {
+        self.font(Font.custom("ppap", size: 34))
+            .foregroundColor(.ezpzLime)
+    }
+    
+    func basicTitle2() -> Text {
+        self.font(Font.custom("ppap", size: 28))
+            .foregroundColor(.grayScale1)
+    }
+    
+    func limeTitle2() -> Text {
+        self.font(Font.custom("ppap", size: 28))
+            .foregroundColor(.ezpzLime)
+    }
+    
+    func pinkTitle3() -> Text {
+        self.font(Font.custom("ppap", size: 24))
+            .foregroundColor(.ezpzPink)
+    }
+    
+    func limeTitle4() -> Text {
+        self.font(Font.custom("ppap", size: 18))
+            .foregroundColor(.ezpzLime)
+    }
+    
+    func basicHeadline() -> Text {
+        self.font(Font.custom("ppap", size: 17))
+            .foregroundColor(.grayScale1)
+    }
+    
+    func limeHeadline() -> Text {
+        self.font(Font.custom("ppap", size: 17))
+            .foregroundColor(.ezpzLime)
+    }
+    
+    func basicBody() -> Text {
+        self.font(Font.custom("ppap", size: 17))
+            .foregroundColor(.grayScale1)
+    }
+    
+    func grayScale3Body() -> Text {
+        self.font(Font.custom("ppap", size: 17))
+            .foregroundColor(.grayScale3)
+    }
+    
+    func grayScale4Body() -> Text {
+        self.font(Font.custom("ppap", size: 17))
+            .foregroundColor(.grayScale4)
+    }
+    
+    func grayScale3Caption() -> Text {
+        self.font(Font.custom("ppap", size: 13))
+            .foregroundColor(.grayScale3)
+    }
+    
+    func limeCaption() -> Text {
+        self.font(Font.custom("ppap", size: 13))
+            .foregroundColor(.ezpzLime)
+    }
+    
+    func grayScale3Headline() -> Text {
+        self.font(Font.custom("ppap", size: 17))
+            .foregroundColor(.grayScale3)
+    }
+}

--- a/EZPZ/EZPZ/Extensions/View+.swift
+++ b/EZPZ/EZPZ/Extensions/View+.swift
@@ -1,0 +1,18 @@
+//
+//  View+.swift
+//  EZPZ
+//
+//  Created by Ruyha on 2022/10/16.
+//
+
+import SwiftUI
+
+extension View {
+    public func EZPZGradient(startPoint: UnitPoint, endPoint: UnitPoint) -> some View {
+        self.overlay(LinearGradient(gradient: .init(colors: [.ezpzLime,.ezpzPink]),
+                                    startPoint: startPoint,
+                                    endPoint: endPoint))
+        .mask(self)
+    }
+}
+

--- a/EZPZ/EZPZ/Fonts/Spoqa Han Sans Bold.ttf
+++ b/EZPZ/EZPZ/Fonts/Spoqa Han Sans Bold.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a6b9b258145e243dfd5f70cc869119c6af708843658e380304bdfe3d4f4eaef
+size 29724416

--- a/EZPZ/EZPZ/Fonts/Spoqa Han Sans Regular.ttf
+++ b/EZPZ/EZPZ/Fonts/Spoqa Han Sans Regular.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f56c8535b6592672ea7f540a67bb5792c34558d72875fc504166a3e2b28b4b1
+size 29648388

--- a/EZPZ/EZPZ/Info.plist
+++ b/EZPZ/EZPZ/Info.plist
@@ -2,9 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIBackgroundModes</key>
+	<key>UIAppFonts</key>
 	<array>
-		<string>remote-notification</string>
+		<string>Spoqa Han Sans Bold.ttf</string>
+		<string>Spoqa Han Sans Regular.ttf</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
### Motivation
- #6 
- 1. 커스텀 컬러들을 시스템 컬러처럼 사용 가능하게 커스텀 하였습니다.
- 2. EZPZGradient 를 만들었습니다.
- 3. 폰트, 사이즈, 색 까지 한번에 저장된 값을 사용 가능합니다.

### Key Change
#### 기존 EZPZ와 다르게 몇가지 변경 사항이 있습니다.

1. 커스텀 컬러들을 시스템 컬러처럼 사용 가능하게 커스텀 하였습니다.
<img src="https://user-images.githubusercontent.com/103024840/196154887-90c7f73c-9ab6-47ce-8ceb-0b89cf84ca22.png" width="300" >

아래의 코드 처럼  편하게 쓰시면됩니다.
```swift
  Color.ezpzBlack
  Color.ezpzLime
```

2. EZPZGradient 를 만들었습니다.
더이상 긴 코드를 작성하지 않아도 됩니다.

```swift 
Color.red
     .EZPZGradient(startPoint: .top, endPoint: .bottom)
```
<img src="https://user-images.githubusercontent.com/103024840/196155883-2720d526-c7d7-4e7d-ab8f-a46b17ad819f.png" width="120" >

```swift
Color.red
    .EZPZGradient(startPoint: .leading, endPoint: .trailing)
```
<img src="https://user-images.githubusercontent.com/103024840/196155952-2797da99-87a6-4b85-8ca6-cec1507ca533.png" width="120" >

3. 폰트, 사이즈, 색 까지 한번에 저장된 값을 사용 가능합니다.
폰트에는 색상을 추가 할 수 없으나 린다가 만들어 주신 파일에 색상 까지 명시 되어 있어서
작업해 봤습니다.
해당 코드는 코드 리뷰로 남겨 놓겠습니다.
<img width="935" alt="스크린샷 2022-10-17 오후 7 41 09" src="https://user-images.githubusercontent.com/103024840/196157498-5c3cda96-ac15-40e2-974d-bee6371f2453.png">

### To Reviewers
폰트의 경우 스케치에 있는 이름 그대로 작성 했는데 앞에 ezpz를 붙이는게 찾기 편할지 
아니면 그냥 지금처럼 쓸지 고민해봐야 할듯 합니다...
